### PR TITLE
Add `secondsBeforeStart` field to auction summary

### DIFF
--- a/lib/EthEventsClient.js
+++ b/lib/EthEventsClient.js
@@ -51,6 +51,7 @@ export default class EthEventsClient {
             minSlotsCount: deploymentParams.minimalNumberOfParticipants,
             whitelistedAddresses: whitelistedAddresses,
             currentBlocktimeInMs: currentBlockTime * 1000,
+            secondsBeforeStart: 0,
         }
 
         let priceFunctionCalculationStart = auctionStart
@@ -69,6 +70,13 @@ export default class EthEventsClient {
         } else if (state === STATE_NOT_STARTED) {
             priceFunctionCalculationStart = mainConfig.validatorAuction.startTimestamp || currentBlockTime
             result.initialPriceInWEI = EthEventsClient.getCurrentPriceAsBigNumber(priceFunctionCalculationStart * 1000, priceFunctionCalculationStart * 1000, deploymentParams.durationInDays, deploymentParams.startPrice).toString()
+
+            if (mainConfig.validatorAuction.startTimestamp !== undefined) {
+                const secondsBeforeStart = mainConfig.validatorAuction.startTimestamp - currentBlockTime
+                if (secondsBeforeStart > 0) {
+                    result.secondsBeforeStart = secondsBeforeStart
+                }
+            }
         }
         result.priceFunction = EthEventsClient.calculateAllSlotPrices(priceFunctionCalculationStart, deploymentParams.durationInDays, deploymentParams.startPrice)
 


### PR DESCRIPTION
This is purely based on time difference between latest block and
env parameter for auction start time

I had an error when I was leaving `secondsBeforeStart` undefined by default so I set it to 0 as default, which also makes sense. I don't mind using None though.